### PR TITLE
Rework workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,6 @@
 name: Build and test
 
 on:
-  push:
   workflow_call:
 
 jobs:
@@ -27,48 +26,3 @@ jobs:
       - name: Run tests (JVM and JS)
         shell: bash
         run: sbt test
-      - name: Run coverage
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
-        run: sbt coverage rootJVM/test rootJVM/coverageReport
-      - name: Authentificate via token
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
-        run: gh auth login --with-token <<< "${{ secrets.GIST_TOKEN }}"
-      - name: Update gist
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
-        run: |
-          # calculate line coverage
-          lines_valid="$(grep -oE -m 1 'lines-valid="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
-          echo "valid lines: $lines_valid"
-          lines_covered="$(grep -oE -m 1 'lines-covered="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
-          echo "covered lines: $lines_covered"
-          line_coverage="$(awk -v lines_valid=$lines_valid -v lines_covered=$lines_covered 'BEGIN {printf "%.2f", lines_covered/lines_valid*100}')"
-          echo "line coverage: $line_coverage"
-          line_round_cov="$(cut -d '.' -f 1 <<< $line_coverage)"
-          line_r="$(( 255 * (100 - line_round_cov) / 100 ))"
-          line_g="$(( 255 * line_round_cov / 100 ))"
-          line_color="$(printf "#%02X%02X%02X\n" "$line_r" "$line_g" "0")"
-          echo "line coverage badge color: $line_color"
-
-          # calculate branch coverage
-          branches_valid="$(grep -oE -m 1 'branches-valid="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
-          echo "valid branches: $branches_valid"
-          branches_covered="$(grep -oE -m 1 'branches-covered="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
-          echo "covered branches: $branches_covered"
-          branch_coverage="$(awk -v branches_valid=$branches_valid -v branches_covered=$branches_covered 'BEGIN {printf "%.2f", branches_covered/branches_valid*100}')"
-          echo "branch coverage: $branch_coverage"
-          branch_round_cov="$(cut -d '.' -f 1 <<< $branch_coverage)"
-          branch_r="$(( 255 * (100 - branch_round_cov) / 100 ))"
-          branch_g="$(( 255 * branch_round_cov / 100 ))"
-          branch_color="$(printf "#%02X%02X%02X\n" "$branch_r" "$branch_g" "0")"
-          echo "branch coverage badge color: $branch_color"
-
-          # update line coverage badge gist
-          echo '{ "schemaVersion": 1, "label": "line coverage", "message": "'"$line_coverage"'%", "color": "'"$line_color"'" }' > powerrules-line-coverage-badge.json
-          gh gist edit 6d46d5386c81a9b73454731cbb5cc358 powerrules-line-coverage-badge.json
-
-          # update branch coverage badge gist
-          echo '{ "schemaVersion": 1, "label": "branch coverage", "message": "'"$branch_coverage"'%", "color": "'"$branch_color"'" }' > powerrules-branch-coverage-badge.json
-          gh gist edit 07f82f2d3ab43091376eb29126e2839c powerrules-branch-coverage-badge.json

--- a/.github/workflows/check-examples.yaml
+++ b/.github/workflows/check-examples.yaml
@@ -1,0 +1,56 @@
+name: Check examples
+
+on:
+  workflow_call:
+
+jobs:
+
+  check-examples:
+    name: Check examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.21
+          apps: sbt
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install Node.js packages
+        shell: bash
+        run: npm ci
+      - name: Compare examples
+        shell: bash
+        run: |
+          shopt -s nullglob
+
+          failures=""
+
+          for file in ./examples/*.powerrules; do
+
+            ref="${file%.powerrules}.ref"
+            rules="${file%.powerrules}.rules"
+
+            if [[ ! -f "$rules" ]]; then
+              failures="$failures\n$file: .rules file not found"
+            else
+              mv "$rules" "$ref"
+              if ! sbt "rootJVM/run $file"; then
+                failures="$failures\n$file: compilation failed"
+              elif ! cmp -s "$ref" "$rules"; then
+                failures="$failures\n$file: compiled version differs"
+              fi
+            fi
+
+          done
+
+          if [[ -z "$failures" ]]; then
+            exit 0
+          else
+            printf "$failures"
+            exit 1
+          fi

--- a/.github/workflows/check-examples.yaml
+++ b/.github/workflows/check-examples.yaml
@@ -2,6 +2,7 @@ name: Check examples
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -1,7 +1,6 @@
 name: Check format
 
 on:
-  push:
   workflow_call:
 
 jobs:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -24,7 +24,6 @@ jobs:
         shell: bash
         run: npm ci
       - name: Run coverage
-        if: ${{ github.ref == 'refs/heads/main' }}
         shell: bash
         run: sbt coverage rootJVM/test rootJVM/coverageReport
       - name: Authentificate via token

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,70 @@
+name: Run coverage
+
+on:
+  workflow_call:
+
+jobs:
+
+  coverage:
+    name: Run coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.21
+          apps: sbt
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install Node.js packages
+        shell: bash
+        run: npm ci
+      - name: Run coverage
+        if: ${{ github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: sbt coverage rootJVM/test rootJVM/coverageReport
+      - name: Authentificate via token
+        if: ${{ github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: gh auth login --with-token <<< "${{ secrets.GIST_TOKEN }}"
+      - name: Update gist
+        if: ${{ github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: |
+          # calculate line coverage
+          lines_valid="$(grep -oE -m 1 'lines-valid="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
+          echo "valid lines: $lines_valid"
+          lines_covered="$(grep -oE -m 1 'lines-covered="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
+          echo "covered lines: $lines_covered"
+          line_coverage="$(awk -v lines_valid=$lines_valid -v lines_covered=$lines_covered 'BEGIN {printf "%.2f", lines_covered/lines_valid*100}')"
+          echo "line coverage: $line_coverage"
+          line_round_cov="$(cut -d '.' -f 1 <<< $line_coverage)"
+          line_r="$(( 255 * (100 - line_round_cov) / 100 ))"
+          line_g="$(( 255 * line_round_cov / 100 ))"
+          line_color="$(printf "#%02X%02X%02X\n" "$line_r" "$line_g" "0")"
+          echo "line coverage badge color: $line_color"
+
+          # calculate branch coverage
+          branches_valid="$(grep -oE -m 1 'branches-valid="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
+          echo "valid branches: $branches_valid"
+          branches_covered="$(grep -oE -m 1 'branches-covered="[^"]+"' jvm/target/scala-3.*/coverage-report/cobertura.xml | cut -d \" -f 2)"
+          echo "covered branches: $branches_covered"
+          branch_coverage="$(awk -v branches_valid=$branches_valid -v branches_covered=$branches_covered 'BEGIN {printf "%.2f", branches_covered/branches_valid*100}')"
+          echo "branch coverage: $branch_coverage"
+          branch_round_cov="$(cut -d '.' -f 1 <<< $branch_coverage)"
+          branch_r="$(( 255 * (100 - branch_round_cov) / 100 ))"
+          branch_g="$(( 255 * branch_round_cov / 100 ))"
+          branch_color="$(printf "#%02X%02X%02X\n" "$branch_r" "$branch_g" "0")"
+          echo "branch coverage badge color: $branch_color"
+
+          # update line coverage badge gist
+          echo '{ "schemaVersion": 1, "label": "line coverage", "message": "'"$line_coverage"'%", "color": "'"$line_color"'" }' > powerrules-line-coverage-badge.json
+          gh gist edit 6d46d5386c81a9b73454731cbb5cc358 powerrules-line-coverage-badge.json
+
+          # update branch coverage badge gist
+          echo '{ "schemaVersion": 1, "label": "branch coverage", "message": "'"$branch_coverage"'%", "color": "'"$branch_color"'" }' > powerrules-branch-coverage-badge.json
+          gh gist edit 07f82f2d3ab43091376eb29126e2839c powerrules-branch-coverage-badge.json

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -18,7 +18,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/coverage.yaml
 
-  check-examples:
-    name: Check examples
-    needs: build
-    uses: ./.github/workflows/check-examples.yaml
+  # check-examples:
+  #   name: Check examples
+  #   needs: build
+  #   uses: ./.github/workflows/check-examples.yaml

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,0 +1,24 @@
+name: On push
+
+on:
+  push:
+
+jobs:
+
+  build:
+    name: Build and test
+    uses: ./.github/workflows/build.yaml
+
+  check-format:
+    name: Check format
+    uses: ./.github/workflows/check-format.yaml
+  
+  coverage:
+    name: Coverage
+    needs: build
+    uses: ./.github/workflows/coverage.yaml
+
+  check-examples:
+    name: Check examples
+    needs: build
+    uses: ./.github/workflows/check-examples.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sed -i 's/^\( *version *:=\).*/\1 "${{ inputs.version }}",/g' build.sbt
           sed -i 's/^\( *"version":\).*/\1 "${{ inputs.version }}",/g' package.json
-          sed -i 's|^!\[Version.*|![Version ${{ inputs.version }}](https://img.shields.io/badge/version-${{ inputs.version }}-blue)|g' README.md
+          # sed -i 's|^!\[Version.*|![Version ${{ inputs.version }}](https://img.shields.io/badge/version-${{ inputs.version }}-blue)|g' README.md
           git commit -am "Set version to ${{ inputs.version }}"
           git tag -a ${{ inputs.version }} -m "Release v${{ inputs.version }}"
       - name: Setup scala
@@ -70,18 +70,24 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
       - name: Get next snapshot version
-        id: new-version
+        id: next-version
         shell: bash
         run: |
           v="$( awk -F. '{ print $1"."$2"."($3 + 1) }' <<< "${{ inputs.version }}" )"
           echo "New snapshot: $v"
-          echo "new-version=$v" >> $GITHUB_OUTPUT
+          echo "next-version=$v" >> $GITHUB_OUTPUT
       - name: Set version to the new snapshot
         shell: bash
         run: |
-          sed -i 's/^\( *version *:=\).*/\1 "${{ steps.new-version.outputs.new-version }}-SNAPSHOT",/g' build.sbt
-          sed -i 's/^\( *"version":\).*/\1 "${{ steps.new-version.outputs.new-version }}-SNAPSHOT",/g' package.json
-          git commit -am "Set version to ${{ steps.new-version.outputs.new-version }}-SNAPSHOT"
+          sed -i 's/^\( *version *:=\).*/\1 "${{ steps.next-version.outputs.next-version }}-SNAPSHOT",/g' build.sbt
+          sed -i 's/^\( *"version":\).*/\1 "${{ steps.next-version.outputs.next-version }}-SNAPSHOT",/g' package.json
+          git commit -am "Set version to ${{ steps.next-version.outputs.next-version }}-SNAPSHOT"
       - name: Push changes
         shell: bash
         run: git push && git push --tags
+      - name: Update version badge gist
+        shell: bash
+        run: |
+          gh auth login --with-token <<< "${{ secrets.GIST_TOKEN }}"
+          echo '{ "schemaVersion": 1, "label": "version", "message": "'"${{ inputs.version }}"'", "color": "blue" }' > powerrules-version-badge.json
+          gh gist edit 332a8f012e03423e217c300418f37718 powerrules-version-badge.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,10 @@ jobs:
     needs: build
     uses: ./.github/workflows/coverage.yaml
 
-  check-examples:
-    name: Check examples
-    needs: build
-    uses: ./.github/workflows/check-examples.yaml
+  # check-examples:
+  #   name: Check examples
+  #   needs: build
+  #   uses: ./.github/workflows/check-examples.yaml
 
   create-release:
     name: Create release
@@ -35,7 +35,7 @@ jobs:
       - build
       - check-format
       - coverage
-      - check-examples
+      # - check-examples
     permissions:
       pages: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,11 @@ on:
 
 jobs:
 
-  check-format:
-    uses: ./.github/workflows/check-format.yaml
-
   build:
     uses: ./.github/workflows/build.yaml
+
+  check-format:
+    uses: ./.github/workflows/check-format.yaml
 
   deploy:
     name: Deploy to github pages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,31 @@ on:
 jobs:
 
   build:
+    name: Build and test
     uses: ./.github/workflows/build.yaml
 
   check-format:
+    name: Check format
     uses: ./.github/workflows/check-format.yaml
+  
+  coverage:
+    name: Coverage
+    needs: build
+    uses: ./.github/workflows/coverage.yaml
 
-  deploy:
-    name: Deploy to github pages
+  check-examples:
+    name: Check examples
+    needs: build
+    uses: ./.github/workflows/check-examples.yaml
+
+  create-release:
+    name: Create release
     runs-on: ubuntu-latest
     needs:
-      - check-format
       - build
+      - check-format
+      - coverage
+      - check-examples
     permissions:
       pages: write
       contents: write

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Moreover, if you have any suggestions, feel free to reach out via GitHub issues 
 - [Teeworlds Automap Tool](https://github.com/ZonsaC/Teeworlds-Automapper)
 - [Teeworlds Rule Generator](https://github.com/tw-tooling/tw-rule-generator)
 
-## Technical Information
+## Scala
 
 This project is cross-compiled for both ScalaJVM and ScalaJS. The shared core is located in the `shared/` directory, while platform-specific code resides in the `js/` or `jvm/` directories.
 
@@ -75,3 +75,22 @@ It will create a new `.rules` file in the current directory, containing the comp
 ### ScalaJS
 
 The ScalaJS component enables building a web-based Powerrules to DDNet rules converter. You can try it [here](https://lomination.github.io/Powerrules/) or build
+
+## Workflows
+
+All workflows are located in the default directory for GitHub workflows i.e. `./github/workflows/`.
+
+The `build.yaml` workflow builds the project and run the tests for both ScalaJVM and ScalaJS plateforms. The `check-format.yaml` workflow uses scalafmt and scalafix to check if the Scala source code is formatted according to the respective given configurations `./.scalafmt.conf` and `./.scalafix.conf` to improve code consistency. Finally, the `coverage.yaml` workflows runs code coverage thanks to sbt-scoverage plugin, then computes the line coverage and branch coverage and, if it is run on a commit on the main branch, update the GitHub Gists responsible for the badges at the begining of this file. These three workflows can be trigger on workflow call.
+
+The `on-push.yaml` workflow is used only to call the three previously mentioned ones: `build.yaml`, `check-format` and `coverage.yaml`. As its name suggests, it is run on every pushed commit, regardless of the branch. Note that it first runs `build.yaml` and `check-format` workflows and then `coverage.yaml` only if the build and tests have succeeded.
+
+The `check-examples.yaml` workflow ensures that each provided compiled PowerRules file in `./examples/*.rules` corresponds exactly to its `.powerrules` file (i.e. it ensures that no change in the compiler has affected the result of the compilation of the examples). It is not automatically run but can be triggered using the GitHub interface thanks to the `workflow_dispatch` tag.
+
+The `release.yaml` workflow creates a new release of the project. It can be triggered manually as the `check-examples.yaml` workflow. The release process includes:
+- running `build.yaml`, `check-format.yaml` and `coverage.yaml` workflows and ensuring they succeed,
+- changing the version to the new release in the `./build.sbt` and `./package.json` files,
+- creating a git tag,
+- building for ScalaJS using `npm run build`,
+- deploying to GitHub pages,
+- chaging the version to the future snapshot in the `./build.sbt` and `./package.json` files,
+- updating the GitHub Gist responsible for the version badge at the begining of this file.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Version 0.5.0](https://img.shields.io/badge/version-0.5.0-blue)
 [![Build](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/build.yaml?branch=main)](https://github.com/lomination/Powerrules/actions/workflows/build.yaml)
+[![Check format](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/check-format.yaml?branch=main&label=check%20format)](https://github.com/lomination/Powerrules/actions/workflows/check-format.yaml)
+<br>
 ![Line coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flomination%2F6d46d5386c81a9b73454731cbb5cc358%2Fraw%2Fpowerrules-line-coverage-badge.json%3Fcachebust%3Ddkjflskjfldkf)
 ![Branch coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flomination%2F07f82f2d3ab43091376eb29126e2839c%2Fraw%2Fpowerrules-branch-coverage-badge.json%3Fcachebust%3Ddkjflskjfldkf)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Version 0.5.0](https://img.shields.io/badge/version-0.5.0-blue)
 [![Build](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/build.yaml?branch=main)](https://github.com/lomination/Powerrules/actions/workflows/build.yaml)
 [![Check format](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/check-format.yaml?branch=main&label=check%20format)](https://github.com/lomination/Powerrules/actions/workflows/check-format.yaml)
+[![Check example](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/check-examples.yaml?branch=main&label=check%20examples)](https://github.com/lomination/Powerrules/actions/workflows/check-examples.yaml)
 <br>
 ![Line coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flomination%2F6d46d5386c81a9b73454731cbb5cc358%2Fraw%2Fpowerrules-line-coverage-badge.json%3Fcachebust%3Ddkjflskjfldkf)
 ![Branch coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flomination%2F07f82f2d3ab43091376eb29126e2839c%2Fraw%2Fpowerrules-branch-coverage-badge.json%3Fcachebust%3Ddkjflskjfldkf)
@@ -33,7 +34,7 @@ Moreover, if you have any suggestions, feel free to reach out via GitHub issues 
 
 ## Usefull Links
 
-### Documentation
+### Related documentation
 
 - [DDNet official wiki](https://wiki.ddnet.org/wiki/Automapper)
 - [Forum post (possibly partially outdated)](https://forum.ddnet.org/viewtopic.php?t=2428)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
 
-![Version 0.5.0](https://img.shields.io/badge/version-0.5.0-blue)
+[![Version badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flomination%2F332a8f012e03423e217c300418f37718%2Fraw%2Fpowerrules-version-badge.json%3Fcachebust%3Ddkjflskjfldkf)
+](https://github.com/lomination/Powerrules/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/build.yaml?branch=main)](https://github.com/lomination/Powerrules/actions/workflows/build.yaml)
 [![Check format](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/check-format.yaml?branch=main&label=check%20format)](https://github.com/lomination/Powerrules/actions/workflows/check-format.yaml)
 [![Check example](https://img.shields.io/github/actions/workflow/status/lomination/Powerrules/.github/workflows/check-examples.yaml?branch=main&label=check%20examples)](https://github.com/lomination/Powerrules/actions/workflows/check-examples.yaml)

--- a/examples/demo.powerrules
+++ b/examples/demo.powerrules
@@ -1,0 +1,5 @@
+[Rule 1]
+
+replace
+    with 1
+    if there is full

--- a/examples/demo.rules
+++ b/examples/demo.rules
@@ -1,0 +1,9 @@
+# Generated with Powerrules (version 0.5.1-SNAPSHOT) by lomination
+# https://github.com/lomination/Powerrules
+
+
+
+[Rule 1]
+
+Index 1 NONE
+NewRun

--- a/jvm/src/main/scala/lomination/powerrules/Main.scala
+++ b/jvm/src/main/scala/lomination/powerrules/Main.scala
@@ -7,11 +7,9 @@ import scala.util.Using
 @main
 def main(fileName: String) =
 
-  val extRegex = """^[\S\s]+?\.(?:[pP][oO][wW][eE][rR][rR][uU][lL][eE][sS]|[tT][xX][tT])$"""
-
   val newFileName =
-    if (fileName.matches(extRegex))
-      fileName.replaceAll("""\.[^.]+$""", ".rules")
+    if (fileName.toLowerCase.endsWith(".powerrules"))
+      fileName.slice(0, fileName.length - 11) + ".rules"
     else
       fileName + ".rules"
 

--- a/shared/src/main/scala/lomination/powerrules/ast/Structs.scala
+++ b/shared/src/main/scala/lomination/powerrules/ast/Structs.scala
@@ -351,10 +351,8 @@ case class Dir(sign: Sign, n: Times):
   /** Rotates this direction by the given direction. This method is associative and commutatives */
   def rotate(dir: Dir): Dir =
     val newSign = if (sign == dir.sign) Sign.+ else Sign.-
-    if sign == Sign.- then
-      Dir(newSign, Times.fromOrdinal((n.ordinal - dir.n.ordinal + 4) % 4))
-    else
-      Dir(newSign, Times.fromOrdinal((n.ordinal + dir.n.ordinal + 4) % 4))
+    if sign == Sign.- then Dir(newSign, Times.fromOrdinal((n.ordinal - dir.n.ordinal + 4) % 4))
+    else Dir(newSign, Times.fromOrdinal((n.ordinal + dir.n.ordinal + 4) % 4))
 
 case object Dir:
 

--- a/shared/src/main/scala/lomination/powerrules/ast/Structs.scala
+++ b/shared/src/main/scala/lomination/powerrules/ast/Structs.scala
@@ -349,10 +349,12 @@ case class Tile(id: Int, dir: Dir = Dir.p0):
 case class Dir(sign: Sign, n: Times):
 
   /** Rotates this direction by the given direction. This method is associative and commutatives */
-  def rotate(dir: Dir): Dir = Dir(
-    if (sign == dir.sign) Sign.+ else Sign.-,
-    Times.fromOrdinal((n.ordinal + dir.n.ordinal) % 4)
-  )
+  def rotate(dir: Dir): Dir =
+    val newSign = if (sign == dir.sign) Sign.+ else Sign.-
+    if sign == Sign.- then
+      Dir(newSign, Times.fromOrdinal((n.ordinal - dir.n.ordinal + 4) % 4))
+    else
+      Dir(newSign, Times.fromOrdinal((n.ordinal + dir.n.ordinal + 4) % 4))
 
 case object Dir:
 

--- a/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
@@ -5,10 +5,24 @@ import lomination.powerrules.lexing.tokens._
 import scala.util.Try
 
 object CommentHandler extends TokenParser {
+
+  /** Removes all comments (single line and multi line comments) from the given token sequence. Note that single line comments do not include the new
+    * line that determines their end.
+    *
+    * @param tokens
+    *   the input token sequence.
+    * @return
+    *   a token sequence where all comments have been removed.
+    */
   def apply(tokens: Seq[Token]): Try[Seq[Token]] =
+    logger.trace("Starting comment handling...")
     parse(mainParser, TokenReader(tokens)) match
-      case Success(tokens, _)     => scala.util.Success(tokens)
-      case NoSuccess.I(msg, next) => scala.util.Failure(Exception(msg + s" at ${next.pos}"))
+      case Success(tokens, _) =>
+        logger.trace("Comment handling succeeded")
+        scala.util.Success(tokens)
+      case NoSuccess.I(msg, next) =>
+        logger.trace(s"Comment handling failed at ${next.pos} due to:\n$msg")
+        scala.util.Failure(Exception(msg + s" at ${next.pos}"))
 
   lazy val mainParser: P[Seq[Token]] =
     rep(singleLineComment | multiLineComment | anyTk)
@@ -16,7 +30,9 @@ object CommentHandler extends TokenParser {
 
   lazy val singleLineComment: P[Unit] =
     slashTk ~ slashTk ~! rep(not(newlineTk) ~ anyTk) ^^^ { () }
+      |< "single line comment"
 
   lazy val multiLineComment: P[Unit] =
     slashTk ~ starTk ~! rep(not(starTk ~ slashTk) ~ anyTk) ~ (starTk ~ slashTk |< "multi line comment end `*/`") ^^^ { () }
+      |< "multi line comment"
 }

--- a/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
@@ -1,0 +1,22 @@
+package lomination.powerrules.lexing
+
+import lomination.powerrules.lexing.tokens._
+
+import scala.util.Try
+
+object CommentHandler extends TokenParser {
+  def apply(tokens: Seq[Token]): Try[Seq[Token]] =
+    parse(mainParser, TokenReader(tokens)) match
+      case Success(tokens, _)     => scala.util.Success(tokens)
+      case NoSuccess.I(msg, next) => scala.util.Failure(Exception(msg + s" at ${next.pos}"))
+
+  lazy val mainParser: P[Seq[Token]] =
+    rep(singleLineComment | multiLineComment | anyTk)
+      ^^ { tokens => tokens collect { case tk: Token => tk } }
+
+  lazy val singleLineComment: P[Unit] =
+    slashTk ~ slashTk ~ rep(not(newlineTk) ~ anyTk) ~ opt(newlineTk) ^^^ { () }
+
+  lazy val multiLineComment: P[Unit] =
+    slashTk ~ starTk ~ rep(not(starTk ~ slashTk) ~ anyTk) ~ starTk ~ slashTk ^^^ { () }
+}

--- a/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/CommentHandler.scala
@@ -15,8 +15,8 @@ object CommentHandler extends TokenParser {
       ^^ { tokens => tokens collect { case tk: Token => tk } }
 
   lazy val singleLineComment: P[Unit] =
-    slashTk ~ slashTk ~ rep(not(newlineTk) ~ anyTk) ~ opt(newlineTk) ^^^ { () }
+    slashTk ~ slashTk ~! rep(not(newlineTk) ~ anyTk) ^^^ { () }
 
   lazy val multiLineComment: P[Unit] =
-    slashTk ~ starTk ~ rep(not(starTk ~ slashTk) ~ anyTk) ~ starTk ~ slashTk ^^^ { () }
+    slashTk ~ starTk ~! rep(not(starTk ~ slashTk) ~ anyTk) ~ (starTk ~ slashTk |< "multi line comment end `*/`") ^^^ { () }
 }

--- a/shared/src/main/scala/lomination/powerrules/lexing/Lexer.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/Lexer.scala
@@ -143,7 +143,7 @@ object Lexer extends RegexParsers {
   // @formatter:off
   
   lazy val tokenParser: P[Unpositioned[Token]] =
-    Seq(literalTk, decimalNumberTk, hexaNumberTk, plusTk, minusTk, pipeTk, starTk, percentTk, leftParentheseTk, rightParentheseTk, leftBracketTk, rightBracketTk, leftBraceTk, rightBraceTk, leftChevronTk, rightChevronTk, commaTk, dollarTk, ampersandTk, dotTk, hashtagTk, spaceTk, newlineTk, tabTk, unknownTk)
+    Seq(literalTk, decimalNumberTk, hexaNumberTk, plusTk, minusTk, pipeTk, starTk, percentTk, leftParentheseTk, rightParentheseTk, leftBracketTk, rightBracketTk, leftBraceTk, rightBraceTk, leftChevronTk, rightChevronTk, commaTk, dollarTk, ampersandTk, dotTk, hashtagTk, slashTk, spaceTk, newlineTk, tabTk, unknownTk)
       .map(phrase)
       .reduce((p1, p2) => p1 | p2)
       .named("token")
@@ -174,6 +174,7 @@ object Lexer extends RegexParsers {
   lazy val ampersandTk       = "&" |>> Ampersand
   lazy val dotTk             = "." |>> Dot
   lazy val hashtagTk         = "#" |>> Hashtag
+  lazy val slashTk           = "/" |>> Slash
 
   lazy val spaceTk   = " "  |>> Space
   lazy val newlineTk = "\n" |>> Newline

--- a/shared/src/main/scala/lomination/powerrules/lexing/TokenParser.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/TokenParser.scala
@@ -51,6 +51,10 @@ class TokenParser extends Parsers {
               error
       } named name
 
+  lazy val anyTk: P[Token] =
+    acceptMatch("any token", { case tk: Token => tk })
+      |< "any token"
+
   lazy val defTk: P[Literal] =
     acceptMatch("`def` token", { case token @ Literal("def", _, _) => token })
       |< "`def` token"
@@ -250,6 +254,10 @@ class TokenParser extends Parsers {
   lazy val hashtagTk: P[Hashtag] =
     acceptMatch("hashtag character `#`", { case token: Hashtag => token })
       |< "hashtag character `#`"
+
+  lazy val slashTk: P[Slash] =
+    acceptMatch("slash character `/`", { case token: Slash => token })
+      |< "slash character `/`"
 
   lazy val spaceTk: P[Space] =
     acceptMatch("space character ` `", { case token: Space => token })

--- a/shared/src/main/scala/lomination/powerrules/lexing/tokens/Token.scala
+++ b/shared/src/main/scala/lomination/powerrules/lexing/tokens/Token.scala
@@ -165,6 +165,9 @@ object Hashtag extends StaticTokenFactory[Hashtag]:
 case class Slash(raw: String, start: Position, end: Position) extends StaticToken(raw, start, end):
   def repos(start: Position, end: Position): Token = new Slash(raw, start, end)
 
+object Slash extends StaticTokenFactory[Slash]:
+  def apply(raw: String, start: Position, end: Position) = new Slash(raw, start, end)
+
 // ---------- Whitespace token parsers ---------- //
 
 case class Space(raw: String, start: Position, end: Position) extends StaticToken(raw, start, end):

--- a/shared/src/test/scala/lomination/powerrules/Util.scala
+++ b/shared/src/test/scala/lomination/powerrules/Util.scala
@@ -1,22 +1,20 @@
 package lomination.powerrules
 
-import lomination.powerrules.lexing.tokens.Token
-
 import scala.util.parsing.input.Position
 
 case class TestPos(l: Int, c: Int) extends Position:
   def line                = l
   def column              = c
-  override def toString   = s"$l"
+  override def toString   = s"$l.$c"
   override def longString = toString
   def lineContents        = ""
 
 object TestPos:
   def apply(l: Int, c: Int): TestPos = new TestPos(l, c)
-  def apply(l: Int): TestPos = new TestPos(l, 0)
+  def apply(l: Int): TestPos         = new TestPos(l, 0)
 
 object Functions:
-  def build(tokens: (Position, Position) => Token*): Seq[Token] =
+  def build[T](tokens: (Position, Position) => T*): Seq[T] =
     tokens.zipWithIndex.map { case f -> i => f.apply(TestPos(i), TestPos(i + 1)) }
 
 object ImplicitConversions:

--- a/shared/src/test/scala/lomination/powerrules/Util.scala
+++ b/shared/src/test/scala/lomination/powerrules/Util.scala
@@ -4,16 +4,24 @@ import lomination.powerrules.lexing.tokens.Token
 
 import scala.util.parsing.input.Position
 
-case class TestPos(l: Int) extends Position:
+case class TestPos(l: Int, c: Int) extends Position:
   def line                = l
-  def column              = 0
+  def column              = c
   override def toString   = s"$l"
   override def longString = toString
   def lineContents        = ""
+
+object TestPos:
+  def apply(l: Int, c: Int): TestPos = new TestPos(l, c)
+  def apply(l: Int): TestPos = new TestPos(l, 0)
 
 object Functions:
   def build(tokens: (Position, Position) => Token*): Seq[Token] =
     tokens.zipWithIndex.map { case f -> i => f.apply(TestPos(i), TestPos(i + 1)) }
 
+object ImplicitConversions:
   given Conversion[Int, TestPos] with
-    def apply(n: Int): TestPos = TestPos(n)
+    def apply(l: Int): TestPos = TestPos(l)
+
+  given Conversion[(Int, Int), TestPos] with
+    def apply(pos: (Int, Int)): TestPos = TestPos(pos._1, pos._2)

--- a/shared/src/test/scala/lomination/powerrules/ast/DirTest.scala
+++ b/shared/src/test/scala/lomination/powerrules/ast/DirTest.scala
@@ -18,7 +18,7 @@ class DirTest extends FunSuite {
 
   test("DirTest - rotate method (3)") {
     val test     = Dir.m2 rotate Dir.m1
-    val expected = Dir.p3
+    val expected = Dir.p1
     assert(clue(test) == clue(expected))
   }
 
@@ -40,9 +40,9 @@ class DirTest extends FunSuite {
     assert(clue(test) == clue(expected))
   }
 
-  test("DirTest - rotate method (7): associativity") {
-    val test     = (Dir.m1 rotate Dir.m2) rotate Dir.p1
-    val expected = Dir.m1 rotate (Dir.m2 rotate Dir.p1)
+  test("DirTest - rotate method (7)") {
+    val test     = Dir.m0 rotate Dir.p1
+    val expected = Dir.m3
     assert(clue(test) == clue(expected))
   }
 

--- a/shared/src/test/scala/lomination/powerrules/formatting/FormatterTest.scala
+++ b/shared/src/test/scala/lomination/powerrules/formatting/FormatterTest.scala
@@ -2,7 +2,7 @@ package lomination.powerrules.formatting
 
 import lomination.powerrules.FunSuite
 import lomination.powerrules.Functions.build
-import lomination.powerrules.Functions.given
+import lomination.powerrules.ImplicitConversions.given
 import lomination.powerrules.config.Config
 import lomination.powerrules.lexing.tokens._
 

--- a/shared/src/test/scala/lomination/powerrules/lexing/CommentHandlerTest.scala
+++ b/shared/src/test/scala/lomination/powerrules/lexing/CommentHandlerTest.scala
@@ -1,0 +1,439 @@
+package lomination.powerrules.lexing
+
+import lomination.powerrules.FunSuite
+import lomination.powerrules.Functions.{build, given_Conversion_Int_TestPos}
+import lomination.powerrules.lexing.tokens._
+
+import scala.language.implicitConversions
+
+class CommentHandlerTest extends FunSuite {
+
+  test("apply method 1 - empty input") {
+    val test     = CommentHandler(Seq())
+    val expected = Seq()
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 2 - no comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Space(" ", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _)
+    )
+    val test     = CommentHandler(tokens)
+    val expected = tokens
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 3 - no comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test     = CommentHandler(tokens)
+    val expected = tokens
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 4 - single line comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 12, 13),
+      Dollar("$", 13, 14),
+      Newline("\n", 14, 15)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 5 - single line comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("Hopefully", _, _),
+      Unknown("^", _, _),
+      Unknown("^", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 16, 17),
+      Dollar("$", 17, 18),
+      Newline("\n", 18, 19)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 6 - single line comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("Hopefully", _, _),
+      Space(" ", _, _),
+      Unknown("^", _, _),
+      Unknown("^", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("Keep", _, _),
+      Space(" ", _, _),
+      Literal("hope", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 17, 18),
+      Newline("\n", 24, 25),
+      Dollar("$", 25, 26),
+      Newline("\n", 26, 27)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 7 - multi line comment") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("Hopefully", _, _),
+      Space(" ", _, _),
+      Unknown("^", _, _),
+      Unknown("^", _, _),
+      Newline("\n", _, _),
+      Literal("Keep", _, _),
+      Space(" ", _, _),
+      Literal("hope", _, _),
+      Space(" ", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 24, 25),
+      Dollar("$", 25, 26),
+      Newline("\n", 26, 27)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 8 - several multi line comments") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("Hopefully", _, _),
+      Space(" ", _, _),
+      Unknown("^", _, _),
+      Unknown("^", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("Keep", _, _),
+      Space(" ", _, _),
+      Literal("hope", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 19, 20),
+      Newline("\n", 28, 29),
+      Dollar("$", 29, 30),
+      Newline("\n", 30, 31)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 9 - nested comments") {
+    val tokens = build(
+      Literal("Hello", _, _),
+      Comma(",", _, _),
+      Newline("\n", _, _),
+      HexaNumber(0x4f, "0x4f", _, _),
+      Plus("+", _, _),
+      DecimalNumber(3, "3", _, _),
+      Unknown("=", _, _),
+      HexaNumber(0x52, "0x52", _, _),
+      Unknown("!", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("Hopefully", _, _),
+      Space(" ", _, _),
+      Unknown("^", _, _),
+      Unknown("^", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("Keep", _, _),
+      Space(" ", _, _),
+      Literal("hope", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Newline("\n", _, _),
+      Dollar("$", _, _),
+      Newline("\n", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hello", 0, 1),
+      Comma(",", 1, 2),
+      Newline("\n", 2, 3),
+      HexaNumber(0x4f, "0x4f", 3, 4),
+      Plus("+", 4, 5),
+      DecimalNumber(3, "3", 5, 6),
+      Unknown("=", 6, 7),
+      HexaNumber(0x52, "0x52", 7, 8),
+      Unknown("!", 8, 9),
+      Newline("\n", 9, 10),
+      Newline("\n", 26, 27),
+      Dollar("$", 27, 28),
+      Newline("\n", 28, 29)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 10 - empty multi line comment") {
+    val tokens = build(
+      Literal("Hey", _, _),
+      Space(" ", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("there", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hey", 0, 1),
+      Space(" ", 1, 2),
+      Space(" ", 6, 7),
+      Literal("there", 7, 8)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 11 - multi line comment") {
+    val tokens = build(
+      Literal("Hey", _, _),
+      Space(" ", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("lomi", _, _),
+      Space(" ", _, _),
+      Star("*", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("there", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hey", 0, 1),
+      Space(" ", 1, 2),
+      Space(" ", 9, 10),
+      Literal("there", 10, 11)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+  test("apply method 12 - failure") {
+    val tokens = build(
+      Literal("Hey", _, _),
+      Space(" ", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("there", _, _)
+    )
+    val test = CommentHandler(tokens)
+    assert(test.isFailure)
+  }
+
+  test("apply method 13 - failure") {
+    val tokens = build(
+      Literal("Hey", _, _),
+      Space(" ", _, _),
+      Slash("/", _, _),
+      Star("*", _, _),
+      Space(" ", _, _),
+      Literal("there", _, _),
+      Space(" ", _, _),
+      Star("*", _, _)
+    )
+    val test = CommentHandler(tokens)
+    assert(test.isFailure)
+  }
+
+  test("apply method 14 - single line comment at the end") {
+    val tokens = build(
+      Literal("Hey", _, _),
+      Newline("\n", _, _),
+      Slash("/", _, _),
+      Slash("/", _, _),
+      Space(" ", _, _),
+      Literal("hello", _, _)
+    )
+    val test = CommentHandler(tokens)
+    val expected = Seq(
+      Literal("Hey", 0, 1),
+      Newline("\n", 1, 2)
+    )
+    assert(test.isSuccess)
+    assert(clue(test.get) == clue(expected))
+  }
+
+}

--- a/shared/src/test/scala/lomination/powerrules/lexing/CommentHandlerTest.scala
+++ b/shared/src/test/scala/lomination/powerrules/lexing/CommentHandlerTest.scala
@@ -1,7 +1,8 @@
 package lomination.powerrules.lexing
 
 import lomination.powerrules.FunSuite
-import lomination.powerrules.Functions.{build, given_Conversion_Int_TestPos}
+import lomination.powerrules.Functions.build
+import lomination.powerrules.ImplicitConversions.given
 import lomination.powerrules.lexing.tokens._
 
 import scala.language.implicitConversions

--- a/shared/src/test/scala/lomination/powerrules/lexing/LexerTest.scala
+++ b/shared/src/test/scala/lomination/powerrules/lexing/LexerTest.scala
@@ -1,0 +1,182 @@
+package lomination.powerrules.lexing
+
+import lomination.powerrules.FunSuite
+import lomination.powerrules.ImplicitConversions.given
+import lomination.powerrules.config.Config
+import lomination.powerrules.lexing.Lexer.Segment
+import lomination.powerrules.lexing.tokens._
+
+import scala.language.implicitConversions
+
+class LexerTest extends FunSuite {
+
+  val cfg = Config()
+
+  test("apply method 1 - empty source") {
+    val source   = ""
+    val obtained = Lexer(source)(using cfg)
+    val expected = Seq()
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("apply method 2 - one line source") {
+    val source   = "Hello there!"
+    val obtained = Lexer(source)(using cfg)
+    val expected = Seq(
+      Literal("Hello", (1, 1), (1, 6)),
+      Space(" ", (1, 6), (1, 7)),
+      Literal("there", (1, 7), (1, 12)),
+      Unknown("!", (1, 12), (1, 13))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("apply method 3 - multi line source with comment") {
+    val source = """|Hello there!
+                    |
+                    |// some comment""".stripMargin
+    val obtained = Lexer(source)(using cfg)
+    val expected = Seq(
+      Literal("Hello", (1, 1), (1, 6)),
+      Space(" ", (1, 6), (1, 7)),
+      Literal("there", (1, 7), (1, 12)),
+      Unknown("!", (1, 12), (1, 13)),
+      Newline("\n", (1, 13), (2, 1)),
+      Newline("\n", (2, 1), (3, 1))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("apply method 4 - multi line source with comment") {
+    val source = """|Hello there!
+                    |/*
+                    |some comment
+                    |*/
+                    |Hello there!""".stripMargin
+    val obtained = Lexer(source)(using cfg)
+    val expected = Seq(
+      Literal("Hello", (1, 1), (1, 6)),
+      Space(" ", (1, 6), (1, 7)),
+      Literal("there", (1, 7), (1, 12)),
+      Unknown("!", (1, 12), (1, 13)),
+      Newline("\n", (1, 13), (2, 1)),
+      Newline("\n", (4, 3), (5, 1)),
+      Literal("Hello", (5, 1), (5, 6)),
+      Space(" ", (5, 6), (5, 7)),
+      Literal("there", (5, 7), (5, 12)),
+      Unknown("!", (5, 12), (5, 13))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("segment method 1 - empty source") {
+    val source   = ""
+    val obtained = Lexer.segment(source)
+    val expected = Seq()
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("segment method 2 - single line source") {
+    val source   = "This is a segment method! ***"
+    val obtained = Lexer.segment(source)
+    val expected = Seq(
+      Segment("This", (1, 1), (1, 5)),
+      Segment(" ", (1, 5), (1, 6)),
+      Segment("is", (1, 6), (1, 8)),
+      Segment(" ", (1, 8), (1, 9)),
+      Segment("a", (1, 9), (1, 10)),
+      Segment(" ", (1, 10), (1, 11)),
+      Segment("segment", (1, 11), (1, 18)),
+      Segment(" ", (1, 18), (1, 19)),
+      Segment("method", (1, 19), (1, 25)),
+      Segment("!", (1, 25), (1, 26)),
+      Segment(" ", (1, 26), (1, 27)),
+      Segment("*", (1, 27), (1, 28)),
+      Segment("*", (1, 28), (1, 29)),
+      Segment("*", (1, 29), (1, 30))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("segment method 3 - multi line source") {
+    val source = """|This is a segment method! ***
+                    |//// @^çà~4?:+)}
+                    |""".stripMargin
+    val obtained = Lexer.segment(source)
+    val expected = Seq(
+      Segment("This", (1, 1), (1, 5)),
+      Segment(" ", (1, 5), (1, 6)),
+      Segment("is", (1, 6), (1, 8)),
+      Segment(" ", (1, 8), (1, 9)),
+      Segment("a", (1, 9), (1, 10)),
+      Segment(" ", (1, 10), (1, 11)),
+      Segment("segment", (1, 11), (1, 18)),
+      Segment(" ", (1, 18), (1, 19)),
+      Segment("method", (1, 19), (1, 25)),
+      Segment("!", (1, 25), (1, 26)),
+      Segment(" ", (1, 26), (1, 27)),
+      Segment("*", (1, 27), (1, 28)),
+      Segment("*", (1, 28), (1, 29)),
+      Segment("*", (1, 29), (1, 30)),
+      Segment("\n", (1, 30), (2, 1)),
+      Segment("/", (2, 1), (2, 2)),
+      Segment("/", (2, 2), (2, 3)),
+      Segment("/", (2, 3), (2, 4)),
+      Segment("/", (2, 4), (2, 5)),
+      Segment(" ", (2, 5), (2, 6)),
+      Segment("@", (2, 6), (2, 7)),
+      Segment("^", (2, 7), (2, 8)),
+      Segment("ç", (2, 8), (2, 9)),
+      Segment("à", (2, 9), (2, 10)),
+      Segment("~", (2, 10), (2, 11)),
+      Segment("4", (2, 11), (2, 12)),
+      Segment("?", (2, 12), (2, 13)),
+      Segment(":", (2, 13), (2, 14)),
+      Segment("+", (2, 14), (2, 15)),
+      Segment(")", (2, 15), (2, 16)),
+      Segment("}", (2, 16), (2, 17)),
+      Segment("\n", (2, 17), (3, 1))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("tokenize method 1 - emtpy source") {
+    val source   = Seq()
+    val obtained = Lexer.tokenize(source)
+    val expected = Seq()
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+  test("tokenize method 2") {
+    val source = Seq(
+      Segment("replace", (1, 1), (1, 8)),
+      Segment(" ", (1, 8), (1, 9)),
+      Segment("with", (1, 9), (1, 13)),
+      Segment(" ", (1, 13), (1, 14)),
+      Segment("0x32", (1, 14), (1, 18)),
+      Segment("+", (1, 18), (1, 19)),
+      Segment("2", (1, 19), (1, 20))
+    )
+    val obtained = Lexer.tokenize(source)
+    val expected = Seq(
+      Literal("replace", (1, 1), (1, 8)),
+      Space(" ", (1, 8), (1, 9)),
+      Literal("with", (1, 9), (1, 13)),
+      Space(" ", (1, 13), (1, 14)),
+      HexaNumber(0x32, "0x32", (1, 14), (1, 18)),
+      Plus("+", (1, 18), (1, 19)),
+      DecimalNumber(2, "2", (1, 19), (1, 20))
+    )
+    assert(obtained.isSuccess)
+    assert(clue(obtained.get) == clue(expected))
+  }
+
+}

--- a/shared/src/test/scala/lomination/powerrules/macros/MacroApplierTest.scala.scala
+++ b/shared/src/test/scala/lomination/powerrules/macros/MacroApplierTest.scala.scala
@@ -2,7 +2,7 @@ package lomination.powerrules.macros
 
 import lomination.powerrules.FunSuite
 import lomination.powerrules.Functions.build
-import lomination.powerrules.Functions.given
+import lomination.powerrules.ImplicitConversions.given
 import lomination.powerrules.lexing.tokens._
 
 import scala.language.implicitConversions


### PR DESCRIPTION
Add a check examples workflow in order to ensure that the compiled version of the future examples correspond to the latest compiler version.
Separate the build workflow from the coverage workflow. Add a on-push workflow to trigger build, coverage, check format and check examples.
Add more workflow badges to the readme.
Simplify the file extension handling in the main function of the JVM root.